### PR TITLE
Validate signature string of invalid length

### DIFF
--- a/src/Standard.Licensing.Tests/LicenseValidationTests.cs
+++ b/src/Standard.Licensing.Tests/LicenseValidationTests.cs
@@ -98,9 +98,39 @@ namespace Standard.Licensing.Tests
         }
 
         [Test]
+        public void Can_Validate_InvalidLength_Signature()
+        {
+            var publicKey =
+                @"MIIBKjCB4wYHKoZIzj0CATCB1wIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAAAAAAAAAAAAD///////////////8wWwQg/////wAAAAEAAAAAAAAAAAAAAAD///////////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvOPD4n0mBLAxUAxJ02CIbnBJNqZnjhE50mt4GffpAEIQNrF9Hy4SxCR/i85uVjpEDydwN9gS3rM6D0oTlF2JjClgIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABNVLQ1xKY80BFMgGXec++Vw7n8vvNrq32PaHuBiYMm0PEj2JoB7qSSWhfgcjxNVJsxqJ6gDQVWgl0r7LH4dr0KU=";
+            var licenseData = @"<License>
+                                  <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
+                                  <Type>Trial</Type>
+                                  <Expiration>Sun, 31 Dec 1899 23:00:00 GMT</Expiration>
+                                  <Quantity>999</Quantity>
+                                  <Customer>
+                                    <Name>John Doe</Name>
+                                    <Email>john@doe.tld</Email>
+                                  </Customer>
+                                  <LicenseAttributes />
+                                  <ProductFeatures />
+                                  <Signature>jIFy27GQIgDz2CndjBh4Vb8tiC3FGQ6fn3GKt8d/P5+luJH0cWv+I=</Signature>
+                                </License>";
+
+            var license = License.Load(licenseData);
+
+            var validationResults = license
+                .Validate()
+                .Signature(publicKey)
+                .AssertValidLicense().ToList();
+
+            Assert.That(validationResults, Is.Not.Null);
+            Assert.That(validationResults.Count(), Is.EqualTo(1));
+            Assert.That(validationResults.FirstOrDefault(), Is.TypeOf<InvalidSignatureValidationFailure>());
+        }
+
+        [Test]
         public void Can_Validate_Expired_ExpirationDate()
         {
-            var publicKey = "";
             var licenseData = @"<License>
                                   <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
                                   <Type>Trial</Type>

--- a/src/Standard.Licensing/License.cs
+++ b/src/Standard.Licensing/License.cs
@@ -232,6 +232,16 @@ namespace Standard.Licensing
             if (signTag == null)
                 return false;
 
+            byte[] signature;
+            try
+            {
+                signature = Convert.FromBase64String(signTag.Value);
+            }
+            catch
+            {
+                return false;
+            }
+
             try
             {
                 signTag.Remove();
@@ -242,8 +252,8 @@ namespace Standard.Licensing
                 var signer = SignerUtilities.GetSigner(signatureAlgorithm);
                 signer.Init(false, pubKey);
                 signer.BlockUpdate(documentToSign, 0, documentToSign.Length);
-
-                return signer.VerifySignature(Convert.FromBase64String(signTag.Value));
+                
+                return signer.VerifySignature(signature);
             }
             finally
             {


### PR DESCRIPTION
Handle the exception if the licence file is modified and the signature is an invalid length.

Should just create an invalid signature validation fault.