### PR TITLE
Add License Keys Using .Net Cryptography APIs to project

### DIFF
--- a/src/Standard.Licensing.LicenseKey.Tests/Extensions/TestExtensions.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/Extensions/TestExtensions.cs
@@ -1,0 +1,6 @@
+﻿namespace Standard.Licensing.LicenseKey.Extensions
+{
+	internal static class TestExtensions
+	{
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/KeyGeneration/StandardLicenseFactoryTests.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/KeyGeneration/StandardLicenseFactoryTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+
+using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey.KeyGeneration
+{
+	public class StandardLicenseFactoryTests
+	{
+		private readonly ILicenseFactory<SimpleTestLicense> _licenseFactory;
+
+		public StandardLicenseFactoryTests()
+		{
+			_licenseFactory =
+				new StandardLicenseFactory<SimpleTestLicense>(
+					SimpleTestLicense.CreateDefaultTestLicense());
+		}
+
+		[Fact]
+		public void Set_ActivationDate_DateSet()
+		{
+			var date = DateTime.UtcNow;
+			_licenseFactory.WithActivationDate(date);
+
+			Assert.Equal(
+				date,
+				_licenseFactory.CreateLicense()
+				   .ActivationDate);
+		}
+
+		[Fact]
+		public void Set_ExpirationDate_DateSet()
+		{
+			var date = DateTime.UtcNow;
+			_licenseFactory.WithExpirationDate(date);
+
+			Assert.Equal(
+				date,
+				_licenseFactory.CreateLicense()
+				   .ExpirationDate);
+		}
+
+		[Fact]
+		public void Set_Type_TypeSet()
+		{
+			_licenseFactory.WithType(LicenseType.Free);
+
+			Assert.Equal(
+				LicenseType.Free,
+				_licenseFactory.CreateLicense()
+				   .LicenseType);
+		}
+
+		[Fact]
+		public void Set_Name_NamSet()
+		{
+			const string name = "some name";
+
+			_licenseFactory.WithName(name);
+			Assert.Equal(
+				name,
+				_licenseFactory.CreateLicense()
+				   .LicenseName);
+		}
+
+		[Fact]
+		public void CreateLicense_ReturnsLicense()
+		{
+			Assert.NotNull(_licenseFactory.CreateLicense());
+		}
+
+		[Fact]
+		public void CreateAndSignLicense_ReturnsValidSignature()
+		{
+			using var signingParameters = new LicenseSigningParameters();
+
+			Assert.NotNull(_licenseFactory.CreateAndSignLicense(signingParameters));
+		}
+
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/KeyValidation/StandardLicenseValidatorTests.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/KeyValidation/StandardLicenseValidatorTests.cs
@@ -1,0 +1,544 @@
+﻿using System;
+using System.Linq;
+
+using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey.KeyValidation
+{
+	public class StandardLicenseValidatorTests
+	{
+		private readonly DateTime _activationDate = DateTime.Today.AddDays(-7);
+		private readonly DateTime _expirationDate = DateTime.Today.AddDays(7);
+		private readonly DateTime _validThrough = DateTime.Today.AddDays(7);
+
+		private const string LicenseName = "Test License";
+		private const string IssuedTo = "Some User";
+
+		private const LicenseType Type = LicenseType.Standard;
+
+		private const int MaxUsers = 500;
+
+
+		private readonly StandardLicenseValidator<SimpleTestLicense> _licenseValidator;
+
+		public StandardLicenseValidatorTests()
+		{
+			var licenseKey = new LicenseKey<SimpleTestLicense>
+			{
+				LicenseType = Type,
+				ExpirationDate = _expirationDate,
+				ActivationDate = _activationDate,
+				LicenseName = LicenseName,
+				KeyData = new SimpleTestLicense
+				{
+					ValidThrough = _validThrough,
+					IssuedTo = IssuedTo,
+					MaxUsers = MaxUsers
+				}
+			};
+
+			_licenseValidator = new StandardLicenseValidator<SimpleTestLicense>(licenseKey);
+		}
+
+		#region ActivatesBefore
+
+		[Fact]
+		public void TestActivatesBefore_GivenValidDate_Succeeds()
+		{
+			Assert.False(
+				_licenseValidator.ActivatesBefore(DateTime.Today)
+				   .Validate()
+				   .HasErrors);
+		}
+
+		[Fact]
+		public void TestActivatesBefore_GivenInvalidDate_Fails()
+		{
+			Assert.True(
+				_licenseValidator.ActivatesBefore(DateTime.Today.AddDays(-14))
+				   .Validate()
+				   .HasErrors);
+		}
+
+		[Fact]
+		public void TestActivatesBefore_GivenInvalidDateAndCustomError_Fails()
+		{
+			const string errorString = "failed";
+			Assert.Equal(
+				errorString,
+				_licenseValidator.ActivatesBefore(DateTime.Today.AddDays(-14), errorString)
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+		}
+
+		[Fact]
+		public void TestActivatesBefore_GivenSameDate_Succeeds()
+		{
+			Assert.False(
+				_licenseValidator.ActivatesBefore(_activationDate)
+				   .Validate()
+				   .HasErrors);
+		}
+
+		#endregion
+
+		#region IfActivatesBefore
+
+		[Fact]
+		public void TestIfActivatesBefore_GivenValidDate_Succeeds()
+		{
+			var called = false;
+			_licenseValidator.IfActivatesBefore(DateTime.Today, date => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfActivatesBefore_GivenBadDate_Fails()
+		{
+			var called = false;
+			_licenseValidator.IfActivatesBefore(DateTime.Today.AddDays(-14), date => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfActivatesBefore_GivenSameDate_Succeeds()
+		{
+			var called = false;
+			_licenseValidator.IfActivatesBefore(_activationDate, date => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region ActivatesAfter
+
+		[Fact]
+		public void TestActivatesAfter_GivenValidDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ActivatesAfter(DateTime.Today.AddDays(-14))
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestActivatesAfter_GivenInvalidDate_Fails()
+			=> Assert.True(
+				_licenseValidator.ActivatesAfter(DateTime.Today.AddDays(14))
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestActivatesAFter_GivenInvalidDateAndCustomError_Fails()
+		{
+			const string errorString = "error";
+			Assert.Equal(
+				errorString,
+				_licenseValidator.ActivatesAfter(DateTime.Today.AddDays(14), errorString)
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+		}
+
+		[Fact]
+		public void TestActivatesAfter_GivenSameDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ActivatesAfter(_activationDate)
+				   .Validate()
+				   .HasErrors);
+
+		#endregion
+
+		#region IfActivatesAfter
+
+		[Fact]
+		public void TestIfActivatesAfter_GivenValidDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfActivatesAfter(DateTime.Today, date => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfActivatesAfter_GivenInvalidDate_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfActivatesAfter(DateTime.Today.AddDays(14), date => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfActivatesAfter_GivenSameDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfActivatesAfter(DateTime.Today, date => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region ExpiresBefore
+
+		[Fact]
+		public void TestExpiresBefore_GivenValidDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ExpiresBefore(DateTime.Today.AddDays(14))
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestExpiresBefore_GivenBadDate_Fails()
+			=> Assert.True(
+				_licenseValidator.ExpiresBefore(DateTime.Today)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestExpiresBefore_GivenBadDateAndCustomError_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.ExpiresBefore(DateTime.Today, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		[Fact]
+		public void TestExpiresBefore_GivenSameDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ExpiresBefore(_expirationDate)
+				   .Validate()
+				   .HasErrors);
+
+		#endregion
+
+		#region IfExpiresBefore
+
+		[Fact]
+		public void TestIfExpiresBefore_GivenValidDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresBefore(DateTime.Today.AddDays(14), time => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfExpiresBefore_GivenBadDate_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresBefore(DateTime.Today, time => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfExpiresBefore_GivenSameDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresBefore(_expirationDate, time => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region ExpiresAfter
+
+		[Fact]
+		public void TestExpiresAfter_GivenValidDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ExpiresAfter(DateTime.Today)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestExpiresAfter_GivenBadDate_Fails()
+			=> Assert.True(
+				_licenseValidator.ExpiresAfter(DateTime.Today.AddDays(14))
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestExpiresAfter_GivenBadDateAndCustomError_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.ExpiresAfter(DateTime.Today.AddDays(14), "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		[Fact]
+		public void TestExpiresAfter_GivenSameDate_Succeeds()
+			=> Assert.False(
+				_licenseValidator.ExpiresAfter(_expirationDate)
+				   .Validate()
+				   .HasErrors);
+
+		#endregion
+
+		#region IfExpiresAfter
+
+		[Fact]
+		public void TestIfExpiresAfter_GivenValidDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresAfter(DateTime.Today, _ => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfExpiresAfter_GivenBadDate_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresAfter(DateTime.Today.AddDays(14), _ => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfExpiresAfter_GivenSameDate_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfExpiresAfter(_expirationDate, _ => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region TypeIs
+
+		[Fact]
+		public void TestTypeIs_GivenValidType_Succeeds()
+			=> Assert.False(
+				_licenseValidator.TypeIs(Type)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestTypeIs_GivenWrongType_Fails()
+			=> Assert.True(
+				_licenseValidator.TypeIs(LicenseType.Enterprise)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestTypeIs_GivenWrongTypeAndErrorMessage_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.TypeIs(LicenseType.Enterprise, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		#endregion
+
+		#region IfTypeIs
+
+		[Fact]
+		public void TestIfTypeIs_GivenValidType_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfTypeIs(Type, _ => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfTypeIs_GivenBadType_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfTypeIs(LicenseType.Enterprise, _ => called = true);
+			Assert.False(called);
+		}
+
+		#endregion
+
+		#region TypeNot
+
+		[Fact]
+		public void TestTypeNot_GivenValidType_Fails()
+			=> Assert.True(
+				_licenseValidator.TypeNot(Type)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestTypeNot_GivenValidTypeAndErrorMessage_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.TypeNot(Type, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		[Fact]
+		public void TestTypeNot_GivenBadType_Succeeds()
+			=> Assert.False(
+				_licenseValidator.TypeNot(LicenseType.Enterprise)
+				   .Validate()
+				   .HasErrors);
+
+		#endregion
+
+		#region IfTypeNot
+
+		[Fact]
+		public void TestIfTypeNot_GivenValidType_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfTypeNot(Type, _ => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfTypeNot_GivenBadType_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfTypeNot(LicenseType.Enterprise, _ => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region NameIs
+
+		[Fact]
+		public void TestNameIs_GivenValidName_Succeeds()
+			=> Assert.False(
+				_licenseValidator.NameIs(LicenseName)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestNameIs_GivenInvalidName_Fails()
+			=> Assert.True(
+				_licenseValidator.NameIs(string.Empty)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestNameIs_GivenInvalidNameAndErrorMessage_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.NameIs(string.Empty, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		#endregion
+
+		#region IfNameIs
+
+		[Fact]
+		public void TestIfNameIs_GivenValidName_Succeeds()
+		{
+			bool called = true;
+			_licenseValidator.IfNameIs(LicenseName, _ => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfNameIs_GivenInvalidName_Fails()
+		{
+			bool called = true;
+			_licenseValidator.IfNameIs(string.Empty, _ => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region NameNot
+
+		[Fact]
+		public void TestNameNot_GivenValidName_Fails()
+			=> Assert.True(
+				_licenseValidator.NameNot(LicenseName)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestNameNot_GivenValidNameAndErrorMessage_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.NameNot(LicenseName, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		[Fact]
+		public void TestNameNot_GivenInvalidName_Succeeds()
+			=> Assert.False(
+				_licenseValidator.NameNot(string.Empty)
+				   .Validate()
+				   .HasErrors);
+
+		#endregion
+
+		#region IfNameNot
+
+		[Fact]
+		public void TestIfNameNot_GivenValidName_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfNameNot(LicenseName, _ => called = true);
+			Assert.False(called);
+		}
+
+		[Fact]
+		public void TestIfNameNot_GivenInvalidName_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfNameNot(string.Empty, _ => called = true);
+			Assert.True(called);
+		}
+
+		#endregion
+
+		#region MeetsCondition
+
+		[Fact]
+		public void TestMeetsCondition_GivenValidCondition_Succeeds()
+			=> Assert.False(
+				_licenseValidator.MeetsCondition(lic => lic.LicenseName == LicenseName)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestMeetsCondition_GivenInvalidCondition_Fails()
+			=> Assert.True(
+				_licenseValidator.MeetsCondition(lic => lic.LicenseName != LicenseName)
+				   .Validate()
+				   .HasErrors);
+
+		[Fact]
+		public void TestMeetsCondition_GivenInvalidConditionWithMessage_Fails()
+			=> Assert.Equal(
+				"error",
+				_licenseValidator.MeetsCondition(lic => lic.LicenseName != LicenseName, "error")
+				   .Validate()
+				   .Errors.FirstOrDefault()
+				?? string.Empty);
+
+		#endregion
+
+		#region IfConditionMet
+
+		[Fact]
+		public void TestIfConditionMet_GivenValidCondition_Succeeds()
+		{
+			bool called = false;
+			_licenseValidator.IfConditionMet(
+				lic => lic.LicenseName == LicenseName,
+				_ => called = true);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void TestIfConditonMet_GivenInvalidConditon_Fails()
+		{
+			bool called = false;
+			_licenseValidator.IfConditionMet(
+				lic => lic.LicenseName != LicenseName,
+				_ => called = true);
+			Assert.False(called);
+		}
+
+		#endregion
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/LicenseKeyTests.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/LicenseKeyTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class LicenseKeyTests
+	{
+		LicenseKey<SimpleTestLicense> _license = new LicenseKey<SimpleTestLicense>();
+
+		[Fact]
+		public void ActivationDateIsUtc()
+		{
+			var date = DateTime.Now;
+			_license.ActivationDate = date;
+			Assert.Equal(date.ToUniversalTime(), _license.ActivationDate);
+		}
+
+		[Fact]
+		public void ExpirationDateIsUTc()
+		{
+			var date = DateTime.Now;
+			_license.ActivationDate = date;
+			Assert.Equal(date.ToUniversalTime(), _license.ActivationDate);
+		}
+
+		[Fact]
+		public void TestCanReadKeyData()
+		{
+			_license.KeyData = new SimpleTestLicense();
+			Assert.NotNull(_license.KeyData);
+		}
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/LifecycleTests.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/LifecycleTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class LifecycleTests
+	{
+
+		[Fact]
+		public void Test_GenerateAndReadLicense_Normal_Succeeds()
+		{
+			using var parameters = new LicenseSigningParameters();
+
+			var license = LicenseKeyManager.Create(new SimpleTestLicense())
+			   .CreateAndSignLicense(parameters);
+
+			var validationResults = LicenseKeyManager.Load<SimpleTestLicense>(license)
+			   .Validate();
+
+			Assert.False(validationResults.HasErrors);
+		}
+
+		[Fact]
+		public void Test_GenerateAndReadLicense_BadSigningParameters_Fails()
+		{
+			using var originalParameters = new LicenseSigningParameters();
+
+			var license = LicenseKeyManager.Create(new SimpleTestLicense())
+			   .CreateAndSignLicense(originalParameters);
+
+			using var newParameters = new LicenseSigningParameters();
+			license = new SignedLicense(license.LicenseData, newParameters.PublicKey);
+
+			Assert.Throws<InvalidOperationException>(
+				() => LicenseKeyManager.Load<SimpleTestLicense>(license)
+				   .Validate());
+		}
+
+		[Fact]
+		public void Test_GenerateAndReadLicense_ExportAndImport_Succeeds()
+		{
+			try
+			{
+				using var parameters = new LicenseSigningParameters();
+
+				parameters.Export("lic.dat");
+				using var importedParameters = LicenseSigningParameters.Import("lic.dat");
+
+				var license = LicenseKeyManager.Create(new SimpleTestLicense())
+				   .CreateAndSignLicense(importedParameters);
+
+				var results = LicenseKeyManager.Load<SimpleTestLicense>(license)
+				   .Validate();
+
+				Assert.False(results.HasErrors);
+			}
+			finally
+			{
+				File.Delete("lic.dat");
+			}
+		}
+
+		[Fact]
+		public async Task Test_GenerateAndReadLicenseAsync_ExportAndImport_Succeeds()
+		{
+			try
+			{
+				using var parameters = new LicenseSigningParameters();
+
+				await parameters.ExportAsync("lic.dat");
+				using var importedParameters =
+					await LicenseSigningParameters.ImportAsync("lic.dat");
+
+				var license = LicenseKeyManager.Create(new SimpleTestLicense())
+				   .CreateAndSignLicense(importedParameters);
+
+				var results = LicenseKeyManager.Load<SimpleTestLicense>(license)
+				   .Validate();
+
+				Assert.False(results.HasErrors);
+			}
+			finally
+			{
+				File.Delete("lic.dat");
+			}
+		}
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/SignedLicenseTests.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/SignedLicenseTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Security.Cryptography;
+
+using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class SignedLicenseTests
+	{
+		[Fact]
+		public void TestSignatureValid_GivenValidSignature_Succeeds()
+		{
+			var token = LicenseKeyManager.Create(new SimpleTestLicense())
+			   .CreateAndSignLicense(new LicenseSigningParameters());
+
+			Assert.True(token.SignatureValid());
+		}
+
+		[Fact]
+		public void TestSignatureValid_GivenInvalidSignature_Fails()
+		{
+			var token = LicenseKeyManager.Create(new SimpleTestLicense())
+			   .CreateAndSignLicense(new LicenseSigningParameters());
+
+			var newSignature = new byte[2048 / 8];
+			RandomNumberGenerator.Fill(newSignature);
+
+			token = new SignedLicense(token.LicenseData, newSignature);
+			
+			Assert.False(token.SignatureValid());
+		}
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/Standard.Licensing.LicenseKey.csproj
+++ b/src/Standard.Licensing.LicenseKey.Tests/Standard.Licensing.LicenseKey.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Standard.Licensing.LicenseKey\Standard.Licensing.LicenseKey.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Standard.Licensing.LicenseKey.Tests/TestLicenseKeyManager.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/TestLicenseKeyManager.cs
@@ -1,0 +1,40 @@
+﻿using Standard.Licensing.LicenseKey.TestLicenses;
+
+using Xunit;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class TestLicenseKeyManager
+	{
+		[Fact]
+		public void TestCanCreateFactory_GivenNoModel()
+			=> Assert.NotNull(LicenseKeyManager.Create());
+
+		[Fact]
+		public void TestCanCreateFactory_GiveLicenseModel()
+			=> Assert.NotNull(LicenseKeyManager.Create(new SimpleTestLicense()));
+
+		[Fact]
+		public void TestCanLoadSignedLicense_GivenSignedLicense()
+			=> Assert.NotNull(
+				LicenseKeyManager.Load(
+					LicenseKeyManager.Create()
+					   .CreateAndSignLicense(new LicenseSigningParameters())));
+
+		[Fact]
+		public void TestCanLoadLicense_GivenLicense()
+			=> Assert.NotNull(LicenseKeyManager.Load(new LicenseKey<object>()));
+
+		[Fact]
+		public void TestCanLoadSignedLicense_GivenBlankLicense()
+			=> Assert.NotNull(
+				LicenseKeyManager.Load<SimpleTestLicense>(
+					LicenseKeyManager.Create(new SimpleTestLicense())
+					   .CreateAndSignLicense(new LicenseSigningParameters())));
+
+		[Fact]
+		public void TestCanLoadLicense_GivenBlankGenericLicense()
+			=> Assert.NotNull(LicenseKeyManager.Load(new LicenseKey<SimpleTestLicense>()));
+
+	}
+}

--- a/src/Standard.Licensing.LicenseKey.Tests/TestLicenses/SimpleTestLicense.cs
+++ b/src/Standard.Licensing.LicenseKey.Tests/TestLicenses/SimpleTestLicense.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Standard.Licensing.LicenseKey.TestLicenses
+{
+	public class SimpleTestLicense
+	{
+		public int MaxUsers { get; set; }
+
+		public string IssuedTo { get; set; } = null!;
+
+		public DateTime ValidThrough { get; set; }
+
+		public static SimpleTestLicense CreateDefaultTestLicense()
+			=> new SimpleTestLicense
+			{
+				MaxUsers = 100,
+				IssuedTo = "Me",
+				ValidThrough = DateTime.Today.AddDays(7)
+			};
+
+		public override bool Equals(object? obj)
+			=> obj != null
+				&& obj is SimpleTestLicense testLicense
+				&& MaxUsers == testLicense.MaxUsers
+				&& IssuedTo == testLicense.IssuedTo
+				&& ValidThrough == testLicense.ValidThrough;
+
+		protected bool Equals(SimpleTestLicense other)
+			=> MaxUsers == other.MaxUsers && IssuedTo == other.IssuedTo && ValidThrough.Equals(other.ValidThrough);
+
+		public override int GetHashCode()
+			=> HashCode.Combine(MaxUsers, IssuedTo, ValidThrough);
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/Internals/Extensions/JsonExtensions.cs
+++ b/src/Standard.Licensing.LicenseKey/Internals/Extensions/JsonExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+
+using Newtonsoft.Json;
+
+namespace Standard.Licensing.LicenseKey.Internals.Extensions
+{
+	internal static class JsonExtensions
+	{
+		internal static string ToJsonString(this object value)
+			=> JsonConvert.SerializeObject(value);
+
+		internal static string ToBase64JsonString(this object value)
+			=> Convert.ToBase64String(Encoding.UTF8.GetBytes(value.ToJsonString()));
+
+		internal static T FromJson<T>(this string value)
+			=> JsonConvert.DeserializeObject<T>(value);
+
+		internal static T FromBase64JsonString<T>(this string value)
+			=> Encoding.UTF8.GetString(Convert.FromBase64String(value))
+			   .FromJson<T>();
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/Jwt/JwtTokenManager.cs
+++ b/src/Standard.Licensing.LicenseKey/Jwt/JwtTokenManager.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+
+using Microsoft.IdentityModel.Tokens;
+
+using Standard.Licensing.LicenseKey.Internals.Extensions;
+
+namespace Standard.Licensing.LicenseKey.Jwt
+{
+	internal sealed class JwtTokenManager
+	{
+		private const string LicenseDataClaim = "ld";
+
+		private readonly LicenseSigningParameters _signingParameters;
+
+		internal JwtTokenManager(LicenseSigningParameters signingParameters)
+		{
+			_signingParameters = signingParameters;
+		}
+
+
+		internal string CreateSecurityToken<T>(LicenseKey<T> licenseKey)
+			=> CreateSecurityTokenInternal(licenseKey.ToBase64JsonString(), licenseKey.LicenseName);
+
+		private string CreateSecurityTokenInternal(string licenseData, string licenseName)
+		{
+			if (_signingParameters.PrivateKey.Length == 0)
+				throw new InvalidOperationException("Cannot sign license without private key");
+
+			var handler = new JwtSecurityTokenHandler();
+
+			var claimsIdentity = new ClaimsIdentity();
+			claimsIdentity.AddClaim(new Claim(ClaimTypes.NameIdentifier, licenseName));
+			claimsIdentity.AddClaim(new Claim(LicenseDataClaim, licenseData));
+
+			var tokenParams = new SecurityTokenDescriptor
+			{
+				Subject = claimsIdentity, SigningCredentials = GenerateSigningCredentials()
+			};
+
+			var token = handler.CreateJwtSecurityToken(tokenParams);
+			return handler.WriteToken(token);
+		}
+
+		internal LicenseKey<T> ParseSecurityToken<T>(string token)
+			=> GetLicenseData(token)
+			   .FromBase64JsonString<LicenseKey<T>>();
+
+		private string GetLicenseData(string token)
+		{
+			var handler = new JwtSecurityTokenHandler();
+
+			var validationParameters = new TokenValidationParameters
+			{
+				ValidateIssuer = false,
+				ValidateAudience = false,
+				ValidateLifetime = false,
+				IssuerSigningKey =
+					new RsaSecurityKey(_signingParameters.Rsa.ExportParameters(false))
+			};
+
+			ClaimsPrincipal claimsPrincipal;
+
+			try
+			{
+				claimsPrincipal = handler.ValidateToken(token, validationParameters, out _);
+			}
+			catch (Exception ex)
+			{
+				throw new InvalidOperationException(
+					"unable to validate token with given public key",
+					ex);
+			}
+
+			if (!claimsPrincipal.Claims.Any())
+				throw new InvalidOperationException("token has no claims");
+
+			return claimsPrincipal.Claims.First()
+			   .Subject.Claims.First(value => value.Type == LicenseDataClaim)
+			   .Value;
+		}
+
+		private SigningCredentials GenerateSigningCredentials()
+			=> new SigningCredentials(
+				new RsaSecurityKey(_signingParameters.Rsa),
+				SecurityAlgorithms.RsaSsaPssSha256);
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/KeyGeneration/ILicenseFactory.cs
+++ b/src/Standard.Licensing.LicenseKey/KeyGeneration/ILicenseFactory.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Standard.Licensing.LicenseKey.KeyGeneration
+{
+	public interface ILicenseFactory<T>
+	{
+		/// <summary>
+		/// configure the activation date with the certain value
+		/// </summary>
+		/// <param name="activationDate">the activation date the license should have</param>
+		/// <returns></returns>
+		ILicenseFactory<T> WithActivationDate(DateTime activationDate);
+
+		/// <summary>
+		/// configure the expiration date the license should have
+		/// </summary>
+		/// <param name="expirationDate">the expiration date the license should have</param>
+		/// <returns></returns>
+		ILicenseFactory<T> WithExpirationDate(DateTime expirationDate);
+
+		/// <summary>
+		/// configure the license type the license should have
+		/// </summary>
+		/// <param name="licenseType">the type of license this should be</param>
+		/// <returns></returns>
+		ILicenseFactory<T> WithType(LicenseType licenseType);
+
+		/// <summary>
+		/// configure the license name that the license should have
+		/// </summary>
+		/// <param name="licenseName">the name that the license should have</param>
+		/// <returns></returns>
+		ILicenseFactory<T> WithName(string licenseName);
+
+		/// <summary>
+		/// creates the license as an object without signing 
+		/// </summary>
+		/// <returns></returns>
+		LicenseKey<T> CreateLicense();
+
+		/// <summary>
+		/// run an operation to create the signed, binary version of the license
+		/// </summary>
+		/// <param name="parameters">the signing parameters the license should have</param>
+		/// <returns></returns>
+		SignedLicense CreateAndSignLicense(LicenseSigningParameters parameters);
+
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/KeyGeneration/StandardLicenseFactory.cs
+++ b/src/Standard.Licensing.LicenseKey/KeyGeneration/StandardLicenseFactory.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Standard.Licensing.LicenseKey.KeyGeneration
+{
+	public class StandardLicenseFactory<T> : ILicenseFactory<T>
+	{
+		private readonly LicenseKey<T> _licenseKey;
+
+		public StandardLicenseFactory()
+		{
+			_licenseKey = new LicenseKey<T>();
+		}
+
+		public StandardLicenseFactory(T licenseInformation)
+		{
+			_licenseKey = new LicenseKey<T>(licenseInformation);
+		}
+
+		public ILicenseFactory<T> WithActivationDate(DateTime activationDate)
+		{
+			_licenseKey.ActivationDate = activationDate.ToUniversalTime();
+			return this;
+		}
+
+		public ILicenseFactory<T> WithExpirationDate(DateTime expirationDate)
+		{
+			_licenseKey.ExpirationDate = expirationDate.ToUniversalTime();
+			return this;
+		}
+
+		public ILicenseFactory<T> WithType(LicenseType licenseType)
+		{
+			_licenseKey.LicenseType = licenseType;
+			return this;
+		}
+
+		public ILicenseFactory<T> WithName(string licenseName)
+		{
+			_licenseKey.LicenseName = licenseName;
+			return this;
+		}
+
+		public LicenseKey<T> CreateLicense()
+			=> _licenseKey;
+
+		public SignedLicense CreateAndSignLicense(LicenseSigningParameters parameters)
+			=> _licenseKey.Sign(parameters);
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/KeyValidation/ILicenseValidator.cs
+++ b/src/Standard.Licensing.LicenseKey/KeyValidation/ILicenseValidator.cs
@@ -1,0 +1,181 @@
+﻿using System;
+
+namespace Standard.Licensing.LicenseKey.KeyValidation
+{
+	public interface ILicenseValidator<T>
+	{
+
+		/// <summary>
+		/// checks to see if the license activates before the given date
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should activate before</param>
+		/// <param name="message">a message to be logged in errors/warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> ActivatesBefore(
+			DateTime dateTime,
+			string message = "");
+
+		/// <summary>
+		/// if the license activates before the given date, run the specified action
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should activate before to trigger the action</param>
+		/// <param name="action">the action that should run if the condition is met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfActivatesBefore(DateTime dateTime, Action<DateTime> action);
+
+		/// <summary>
+		/// check to see if the license activates after the given date
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should activate after</param>
+		/// <param name="message">a message to be logged in errors/warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> ActivatesAfter(
+			DateTime dateTime,
+			string message = "");
+
+		/// <summary>
+		/// checks to see if the license activates after the given date, if true runs an action
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should activate after to trigger the action</param>
+		/// <param name="action">the action that should be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfActivatesAfter(DateTime dateTime, Action<DateTime> action);
+
+		/// <summary>
+		/// check to see if the license expires before the given date / time
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should expire before</param>
+		/// <param name="message">the message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> ExpiresBefore(
+			DateTime dateTime,
+			string message = "");
+
+		/// <summary>
+		/// checks to see if the license expires before the given date, if true runs an action
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should expire before to trigger the action</param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfExpiresBefore(DateTime dateTime, Action<DateTime> action);
+
+		/// <summary>
+		/// check to see if the license expires after the given date / time
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should expire after</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> ExpiresAfter(
+			DateTime dateTime,
+			string message = "");
+
+		/// <summary>
+		/// checks if the license expires after the given date / time, if true runs an action
+		/// </summary>
+		/// <param name="dateTime">the date / time that the license should expire after to trigger the action</param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfExpiresAfter(DateTime dateTime, Action<DateTime> action);
+
+		/// <summary>
+		/// check if the license type is a certain type
+		/// </summary>
+		/// <param name="licenseType">the type of license that the license should be</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> TypeIs(
+			LicenseType licenseType,
+			string message = "");
+
+		/// <summary>
+		/// checks if the license is of a certain type, if true runs an action
+		/// </summary>
+		/// <param name="licenseType">the type of license that the license should be to trigger the action</param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfTypeIs(LicenseType licenseType, Action<LicenseType> action);
+
+		/// <summary>
+		/// check to see if the license type is not a certain value
+		/// </summary>
+		/// <param name="licenseType">the type of license that our license should not be</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> TypeNot(
+			LicenseType licenseType,
+			string message = "");
+
+		/// <summary>
+		/// checks if the license is not of a certain type, if true runs an action
+		/// </summary>
+		/// <param name="licenseType">the type of license that the license should not be to trigger the action </param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfTypeNot(LicenseType licenseType, Action<LicenseType> action);
+
+		/// <summary>
+		/// checks if the license has a certain name
+		/// </summary>
+		/// <param name="licenseName">the name that the license should have</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> NameIs(
+			string licenseName,
+			string message = "");
+
+		/// <summary>
+		/// checks to see if a license name is a certain value, if true runs an action
+		/// </summary>
+		/// <param name="licenseName">the name that the license should have</param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfNameIs(string licenseName, Action<string> action);
+
+		/// <summary>
+		/// checks to see if a license name is not a certain value, if that value logs an error
+		/// </summary>
+		/// <param name="licenseName">the name that the license should not have</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> NameNot(
+			string licenseName,
+			string message = "");
+
+		/// <summary>
+		/// checks to see if the name is not a certain value, if true runs an action
+		/// </summary>
+		/// <param name="licenseName">the name that the license should not have</param>
+		/// <param name="action">the action that will be run on condition met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfNameNot(string licenseName, Action<string> action);
+
+		/// <summary>
+		/// checks to see if the license meets a certain user-specified condition
+		/// </summary>
+		/// <param name="condition">the condition that should be true to validate the license</param>
+		/// <param name="message">a message to be logged in errors / warnings if the validation fails</param>
+		/// <returns></returns>
+		ILicenseValidator<T> MeetsCondition(
+			Func<LicenseKey<T>, bool> condition,
+			string message = "");
+
+		/// <summary>
+		/// checks if a custom user-defined condition is met, if true runs an action
+		/// </summary>
+		/// <param name="condition">a custom user-defined condition that should be met to run the action</param>
+		/// <param name="action">the action that will be run if the condition is met</param>
+		/// <returns></returns>
+		ILicenseValidator<T> IfConditionMet(
+			Func<LicenseKey<T>, bool> condition,
+			Action<LicenseKey<T>> action);
+
+		/// <summary>
+		/// get the underlying license from the validator
+		/// </summary>
+		/// <param name="licenseKey">the underlying license key</param>
+		/// <returns></returns>
+		ILicenseValidator<T> GetLicenseKey(out LicenseKey<T> licenseKey);
+
+		LicenseValidationResults<T> Validate();
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/KeyValidation/LicenseValidationResults.cs
+++ b/src/Standard.Licensing.LicenseKey/KeyValidation/LicenseValidationResults.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Standard.Licensing.LicenseKey.KeyValidation
+{
+	public class LicenseValidationResults<T>
+	{
+		public bool HasErrors => Errors.Any();
+
+		public IReadOnlyCollection<string> Errors { get; internal set; }
+
+		public LicenseKey<T> LicenseKey { get; internal set; }
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/KeyValidation/StandardLicenseValidator.cs
+++ b/src/Standard.Licensing.LicenseKey/KeyValidation/StandardLicenseValidator.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Standard.Licensing.LicenseKey.Jwt;
+
+namespace Standard.Licensing.LicenseKey.KeyValidation
+{
+	public sealed class StandardLicenseValidator<T> : ILicenseValidator<T>
+	{
+		private readonly LicenseKey<T> _licenseKey;
+
+		private readonly List<string> _errors = new List<string>();
+
+		public StandardLicenseValidator(SignedLicense license)
+			=> _licenseKey =
+				new JwtTokenManager(new LicenseSigningParameters(license.PublicKey))
+				   .ParseSecurityToken<T>(license.LicenseData);
+
+		public StandardLicenseValidator(LicenseKey<T> licenseKey)
+			=> _licenseKey = licenseKey;
+
+		public ILicenseValidator<T> ActivatesBefore(
+			DateTime dateTime,
+			string message = "")
+		{
+			if (_licenseKey.ActivationDate <= dateTime.ToUniversalTime())
+				return this;
+			message = string.IsNullOrWhiteSpace(message)
+				? $"Activation date {_licenseKey.ActivationDate} after {dateTime}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfActivatesBefore(DateTime dateTime, Action<DateTime> action)
+		{
+			if (_licenseKey.ActivationDate <= dateTime.ToUniversalTime())
+				action(_licenseKey.ActivationDate);
+			return this;
+		}
+
+		public ILicenseValidator<T> ActivatesAfter(
+			DateTime dateTime,
+			string message = "")
+		{
+			if (_licenseKey.ActivationDate >= dateTime.ToUniversalTime())
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"activation date {_licenseKey.ActivationDate} before {dateTime}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfActivatesAfter(DateTime dateTime, Action<DateTime> action)
+		{
+			if (_licenseKey.ExpirationDate >= dateTime.ToUniversalTime())
+				action(_licenseKey.ActivationDate);
+			return this;
+		}
+
+		public ILicenseValidator<T> ExpiresBefore(
+			DateTime dateTime,
+			string message = "")
+		{
+			if (_licenseKey.ExpirationDate <= dateTime.ToUniversalTime())
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"expiration date {_licenseKey.ExpirationDate} after {dateTime}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfExpiresBefore(DateTime dateTime, Action<DateTime> action)
+		{
+			if (_licenseKey.ExpirationDate <= dateTime.ToUniversalTime())
+				action(_licenseKey.ActivationDate);
+			return this;
+		}
+
+		public ILicenseValidator<T> ExpiresAfter(
+			DateTime dateTime,
+			string message = "")
+		{
+			if (_licenseKey.ExpirationDate >= dateTime.ToUniversalTime())
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"expiration date {_licenseKey.ExpirationDate} after {dateTime}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfExpiresAfter(DateTime dateTime, Action<DateTime> action)
+		{
+			if (_licenseKey.ExpirationDate >= dateTime.ToUniversalTime())
+				action(_licenseKey.ActivationDate);
+			return this;
+		}
+
+		public ILicenseValidator<T> TypeIs(
+			LicenseType licenseType,
+			string message = "")
+		{
+			if (_licenseKey.LicenseType == licenseType)
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"license requires {Enum.GetName(typeof(LicenseType), licenseType)}, "
+				+ $"got {Enum.GetName(typeof(LicenseType), _licenseKey.LicenseType)} is not valid"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfTypeIs(LicenseType licenseType, Action<LicenseType> action)
+		{
+			if (_licenseKey.LicenseType == licenseType)
+				action(_licenseKey.LicenseType);
+			return this;
+		}
+
+		public ILicenseValidator<T> TypeNot(
+			LicenseType licenseType,
+			string message = "")
+		{
+			if (_licenseKey.LicenseType != licenseType)
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"license cannot be {Enum.GetName(typeof(LicenseType), licenseType)}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfTypeNot(LicenseType licenseType, Action<LicenseType> action)
+		{
+			if (_licenseKey.LicenseType != licenseType)
+				action(_licenseKey.LicenseType);
+			return this;
+		}
+
+		public ILicenseValidator<T> NameIs(
+			string licenseName,
+			string message = "")
+		{
+			if (_licenseKey.LicenseName == licenseName)
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"license name \"{_licenseKey.LicenseName}\" does not match {licenseName}"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfNameIs(string licenseName, Action<string> action)
+		{
+			if (_licenseKey.LicenseName == licenseName)
+				action(_licenseKey.LicenseName);
+			return this;
+		}
+
+		public ILicenseValidator<T> NameNot(
+			string licenseName,
+			string message = "")
+		{
+			if (_licenseKey.LicenseName != licenseName)
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? $"license name should not be \"{_licenseKey.LicenseName}\""
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfNameNot(string licenseName, Action<string> action)
+		{
+			if (_licenseKey.LicenseName != licenseName)
+				action(_licenseKey.LicenseName);
+			return this;
+		}
+
+		public ILicenseValidator<T> MeetsCondition(
+			Func<LicenseKey<T>, bool> condition,
+			string message = "")
+		{
+			if (condition(_licenseKey))
+				return this;
+
+			message = string.IsNullOrWhiteSpace(message)
+				? "check failed custom condition"
+				: message;
+
+			_errors.Add(message);
+			return this;
+		}
+
+		public ILicenseValidator<T> IfConditionMet(
+			Func<LicenseKey<T>, bool> condition,
+			Action<LicenseKey<T>> action)
+		{
+			if (condition(_licenseKey))
+				action(_licenseKey);
+			return this;
+		}
+
+		public ILicenseValidator<T> GetLicenseKey(out LicenseKey <T>licenseKey)
+		{
+			licenseKey = _licenseKey;
+			return this;
+		}
+
+		public LicenseValidationResults<T> Validate()
+			=> new LicenseValidationResults<T>
+			{
+				Errors = _errors.AsReadOnly(), LicenseKey = _licenseKey
+			};
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/LicenseKey.cs
+++ b/src/Standard.Licensing.LicenseKey/LicenseKey.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+using Newtonsoft.Json;
+
+using Standard.Licensing.LicenseKey.Internals.Extensions;
+using Standard.Licensing.LicenseKey.Jwt;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class LicenseKey<T>
+	{
+		[JsonProperty("ad")]
+		private DateTime _activationDate = DateTime.UnixEpoch.ToUniversalTime();
+
+		public DateTime ActivationDate
+		{
+			get => _activationDate.ToUniversalTime();
+			set => _activationDate = value.ToUniversalTime();
+		}
+
+		[JsonProperty("ed")]
+		private DateTime _expirationDate = DateTime.MaxValue.ToUniversalTime();
+
+		public DateTime ExpirationDate
+		{
+			get => _expirationDate.ToUniversalTime();
+			set => _expirationDate = value.ToUniversalTime();
+		}
+
+		[JsonProperty("lt")]
+		public LicenseType LicenseType { get; set; } = LicenseType.Standard;
+
+		[JsonProperty("ln")]
+		public string LicenseName { get; set; } = string.Empty;
+
+		[JsonProperty("ekd")]
+		internal string EncodedKeyData { get; set; }
+
+		[JsonIgnore]
+		public T KeyData
+		{
+			get => EncodedKeyData.FromBase64JsonString<T>();
+			set => EncodedKeyData = value.ToBase64JsonString();
+		}
+
+		public LicenseKey()
+		{
+		}
+
+		public LicenseKey(T keyData)
+		{
+			KeyData = keyData;
+		}
+
+		public SignedLicense Sign(LicenseSigningParameters parameters)
+			=> new SignedLicense(
+				new JwtTokenManager(parameters).CreateSecurityToken(this),
+				parameters.PublicKey);
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/LicenseKeyManager.cs
+++ b/src/Standard.Licensing.LicenseKey/LicenseKeyManager.cs
@@ -1,0 +1,28 @@
+﻿using Standard.Licensing.LicenseKey.KeyGeneration;
+using Standard.Licensing.LicenseKey.KeyValidation;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public static class LicenseKeyManager
+	{
+
+		public static ILicenseFactory<object> Create()
+			=> new StandardLicenseFactory<object>(new LicenseKey<object>());
+
+		public static ILicenseFactory<T> Create<T>(T licenseData)
+			=> new StandardLicenseFactory<T>(licenseData);
+
+		public static ILicenseValidator<object> Load(SignedLicense signedLicense)
+			=> Load<object>(signedLicense);
+
+		public static ILicenseValidator<object> Load(LicenseKey<object> license)
+			=> new StandardLicenseValidator<object>(license);
+
+		public static ILicenseValidator<T> Load<T>(SignedLicense signedLicense)
+			=> new StandardLicenseValidator<T>(signedLicense);
+
+		public static ILicenseValidator<T> Load<T>(LicenseKey<T> licenseKey)
+			=> new StandardLicenseValidator<T>(licenseKey);
+
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/LicenseSigningParameters.cs
+++ b/src/Standard.Licensing.LicenseKey/LicenseSigningParameters.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using Standard.Licensing.LicenseKey.Internals.Extensions;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class LicenseSigningParameters : IDisposable
+	{
+		public byte[] PublicKey => Rsa.ExportRSAPublicKey();
+
+		public byte[] PrivateKey
+		{
+			get
+			{
+				try
+				{
+					return Rsa.ExportRSAPrivateKey();
+				}
+				catch
+				{
+					return new byte[0];
+				}
+			}
+		}
+
+		[JsonIgnore] internal readonly RSA Rsa;
+
+
+		/// <summary>
+		/// generate signing credentials with a new key
+		/// <param name="keySize"></param>
+		/// </summary>
+		public LicenseSigningParameters(int keySize = 2048)
+		{
+			Rsa = RSA.Create(keySize);
+		}
+
+		/// <summary>
+		/// generate signing credentials with public key only
+		/// </summary>
+		/// <param name="publicKey"></param>
+		/// <param name="keySize"></param>
+		public LicenseSigningParameters(byte[] publicKey, int keySize = 2048) : this(keySize)
+		{
+			Rsa.ImportRSAPublicKey(publicKey, out int _);
+		}
+
+		/// <summary>
+		/// generate signing credentials with both public and private key
+		/// </summary>
+		/// <param name="publicKey">the rsa public key</param>
+		/// <param name="privateKey">the rsa private key</param>
+		/// <param name="keySize"></param>
+		public LicenseSigningParameters(
+			byte[] publicKey,
+			byte[] privateKey,
+			int keySize = 2048) : this(keySize)
+		{
+			Rsa.ImportRSAPublicKey(publicKey, out _);
+			Rsa.ImportRSAPrivateKey(privateKey, out _);
+		}
+
+		public void Export(string path)
+			=> File.WriteAllText(
+				path,
+				GenerateParametersDto()
+				   .ToJsonString());
+
+		public Task ExportAsync(string path, CancellationToken cancellationToken = default)
+			=> File.WriteAllTextAsync(
+				path,
+				GenerateParametersDto()
+				   .ToJsonString(),
+				cancellationToken);
+
+		private LicenseParametersDto GenerateParametersDto()
+			=> new LicenseParametersDto
+			{
+				PrivateKey = PrivateKey,
+				PublicKey = PublicKey,
+				KeyLength = Rsa.KeySize
+			};
+
+		public static LicenseSigningParameters Import(string path)
+		{
+			var parameters = File.ReadAllText(path)
+			   .FromJson<LicenseParametersDto>();
+			return new LicenseSigningParameters(
+				parameters.PublicKey,
+				parameters.PrivateKey,
+				parameters.KeyLength);
+		}
+
+		public static async Task<LicenseSigningParameters> ImportAsync(
+			string path,
+			CancellationToken cancellationToken = default)
+		{
+			var fileContents = await File.ReadAllTextAsync(path, cancellationToken);
+			var parameters = fileContents.FromJson<LicenseParametersDto>();
+			return new LicenseSigningParameters(
+				parameters.PublicKey,
+				parameters.PrivateKey,
+				parameters.KeyLength);
+		}
+
+		public void Dispose()
+		{
+			Rsa?.Dispose();
+		}
+	}
+
+	internal class LicenseParametersDto
+	{
+		public byte[] PrivateKey { get; set; }
+
+		public byte[] PublicKey { get; set; }
+
+		public int KeyLength { get; set; }
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/LicenseType.cs
+++ b/src/Standard.Licensing.LicenseKey/LicenseType.cs
@@ -1,0 +1,10 @@
+﻿namespace Standard.Licensing.LicenseKey
+{
+	public enum LicenseType
+	{
+		Standard,
+		Enterprise,
+		Free,
+		Trial
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/README.md
+++ b/src/Standard.Licensing.LicenseKey/README.md
@@ -1,0 +1,120 @@
+﻿## Usage
+
+### Creating License Signing Parameters
+
+StandardLicensing License Keys uses .Net's Cryptology APIs to create and sign the license keys it generates, more specifically, the `RsaSsaPssSha256` algorithm. Keys can be any length in bits that the RSA algorithm permits (512, 1024, 3096, etc...). The default is 2048 bits.
+
+#### Generating New License Parameters
+
+You can generate new keys for license signing by instantiating the `LicenseSigningParameters` with no arguments or one argument representing your desired key size.
+
+```csharp
+// optionally you can pass the key size, defaults to 2048 bits
+using var licenseParameters = new LicenseSigningParameters();
+```
+
+#### Saving License Parameters
+
+If you wish to store your public key in your application or simply wish to use the same private key for every new license you generate you will have to save your license parameters. This can be accomplished easily with the `Export` and `Import` methods which also support asynchronous code.
+
+```csharp
+licenseParameters.Export("keys.txt");
+// then, when you need the keys again
+using var signingParameters = LicenseSigningParameters.Import("keys.txt");
+```
+
+### Creating the License Generator
+
+StandardLicensing License Keys supports a base set of fields for licenses, but also has functionality to support further configuration through generics. This allows you to specify further strongly typed license details in the `KeyData` property.
+
+```Csharp
+public class TestLicense 
+{
+    public int MaxUsers { get; set; }
+
+    public string IssuedTo { get; set; }
+}
+```
+
+#### Using the Fluent API
+
+StandardLicensing License Keys also supports a fluent API to configure all of its license properties.
+
+```CSharp
+using var signingParameters = new LicenseSigningParameters();
+
+var licenseInformation = new TestLicense
+{
+    MaxUsers = 10000,
+    IssuedTo = "Some Random User"
+};
+
+var signedLicense = LicenseKeyManager.Create(licenseInformation)
+    .WithName("Test License")
+    .WithType(LicenseType.Enterprise)
+    .WithActivationDate(DateTime.UtcNow.AddDays(1))
+    .WithExpirationDate(DateTime.UtcNow.AddDays(30))
+    .CreateAndSignLicense(signingParameters);
+```
+
+#### Using Standard Assignments
+
+If you do not want to use the fluent API for creation you can call `CreateLicense` on the `ILicenseFactory` interface and manipulate the license with standard assignments, then sign the license later on with the `Sign` method. Example:
+
+```csharp
+using var signingParameters = new LicenseSigningParameters();
+
+var licenseInformation = new TestLicense
+{
+    MaxUsers = 10000,
+    IssuedTo = "Some Random User"
+};
+
+var license = LicenseKeyManager.Create(licenseInformation)
+    .CreateLicense();
+
+license.ExpirationDate = DateTime.UtcNow.AddDays(7);
+license.LicenseType = LicenseType.Standard;
+var signedLicense = license.Sign(signingParameters)
+```
+
+Once you have generated the license then you are free to transport it anywhere. So long as the public key is present the validator should be able to check its contents.
+
+### Validate The License in Your Application
+
+The license data can be stored however you please, however once you start to validate the license you must reconstruct the `SignedLicense` object that the license was originally exported as. This class only consists of two fields, `PublicKey` and `LienseData` so this is not hard to do.
+
+```csharp
+var licenseData = GetLicenseData();
+var publicKey = GetLicenseKey();
+
+var signedLicense = new SignedLicense(licenseData, publicKey);
+```
+
+once you have the `SignedLicense` object, you can use the license validation API to validate your license.
+
+```Csharp
+
+var signedLicense = GetSignedLicense();
+
+if(!signedLicense.SignatureValid())
+    throw new Exception("This license has been tampered with!");
+
+var validationResults = LicenseKeyManager.Load<TestLicense>(signedLicense)
+    .TypeNot(LicenseType.Trial)
+    .ActivatesBefore(DateTime.UtcNow)
+    .ExpiresAfter(DateTime.UtcNow, "License is expired")
+    .MeetsCondition(license => license.LicenseData.IssuedTo == "Some Random User",
+        "This license was issued to Some Random User, and you're not them!")
+    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate 
+        => Console.WriteLine("warning, license expires soon")
+    .Validate();
+
+if(validationResults.HasErrors)
+    foreach(var error in validationResults.Errors)
+        Console.WriteLine(error);
+```
+
+StandardLicensing License Keys will not throw any exceptions unless it fails to authenticate the license with its public key.
+
+All errors will be put in the `Errors` property on the `LicenseValidationResults<T>` class and the user will be able to enumerate them manually. This class also exposes the physical license in the `LicenseKey` property, so license values can be read after validation.

--- a/src/Standard.Licensing.LicenseKey/SignedLicense.cs
+++ b/src/Standard.Licensing.LicenseKey/SignedLicense.cs
@@ -1,0 +1,35 @@
+﻿using Standard.Licensing.LicenseKey.Jwt;
+
+namespace Standard.Licensing.LicenseKey
+{
+	public class SignedLicense
+	{
+		public string LicenseData { get; }
+		public byte[] PublicKey { get; }
+
+		public SignedLicense(string licenseData, byte[] publicKey)
+		{
+			LicenseData = licenseData;
+			PublicKey = publicKey;
+		}
+
+		/// <summary>
+		/// validate that the token has a valid signature
+		/// </summary>
+		/// <returns>true if the signature is valid, false otherwise</returns>
+		public bool SignatureValid()
+		{
+			try
+			{
+				var tokenManager = new JwtTokenManager(new LicenseSigningParameters(PublicKey));
+				tokenManager.ParseSecurityToken<object>(LicenseData);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+	}
+}

--- a/src/Standard.Licensing.LicenseKey/Standard.Licensing.LicenseKey.csproj
+++ b/src/Standard.Licensing.LicenseKey/Standard.Licensing.LicenseKey.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Standard.Licensing.sln
+++ b/src/Standard.Licensing.sln
@@ -1,8 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standard.Licensing", "Standard.Licensing\Standard.Licensing.csproj", "{C658755A-2F60-430B-A41E-9C11C817B909}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standard.Licensing.LicenseKey", "Standard.Licensing.LicenseKey\Standard.Licensing.LicenseKey.csproj", "{A115D5FF-D2B7-45AE-9B9F-C6F9C522A2EA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{3867EFA4-5A6E-44E2-9D48-250F4FA970AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standard.Licensing.LicenseKey", "Standard.Licensing.LicenseKey.Tests\Standard.Licensing.LicenseKey.csproj", "{0A8233B2-66EB-4841-A11B-C4AFB689F9CD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +20,20 @@ Global
 		{C658755A-2F60-430B-A41E-9C11C817B909}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C658755A-2F60-430B-A41E-9C11C817B909}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C658755A-2F60-430B-A41E-9C11C817B909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A115D5FF-D2B7-45AE-9B9F-C6F9C522A2EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A115D5FF-D2B7-45AE-9B9F-C6F9C522A2EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A115D5FF-D2B7-45AE-9B9F-C6F9C522A2EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A115D5FF-D2B7-45AE-9B9F-C6F9C522A2EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A8233B2-66EB-4841-A11B-C4AFB689F9CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A8233B2-66EB-4841-A11B-C4AFB689F9CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A8233B2-66EB-4841-A11B-C4AFB689F9CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A8233B2-66EB-4841-A11B-C4AFB689F9CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0A8233B2-66EB-4841-A11B-C4AFB689F9CD} = {3867EFA4-5A6E-44E2-9D48-250F4FA970AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3F37C526-1AB2-414B-B7FE-58B8066A6351}


### PR DESCRIPTION
This  code is a massive effort I've been working on in spare time over the last few months for a school project. There is a readme attached in the PR detailing the new API that I have created for this repository.

Here's the contents of the Readme as they exist now.

## Usage

### Creating License Signing Parameters

StandardLicensing License Keys uses .Net's Cryptology APIs to create and sign the license keys it generates, more specifically, the `RsaSsaPssSha256` algorithm. Keys can be any length in bits that the RSA algorithm permits (512, 1024, 3096, etc...). The default is 2048 bits.

#### Generating New License Parameters

You can generate new keys for license signing by instantiating the `LicenseSigningParameters` with no arguments or one argument representing your desired key size.

```csharp
// optionally you can pass the key size, defaults to 2048 bits
using var licenseParameters = new LicenseSigningParameters();
```

#### Saving License Parameters

If you wish to store your public key in your application or simply wish to use the same private key for every new license you generate you will have to save your license parameters. This can be accomplished easily with the `Export` and `Import` methods which also support asynchronous code.

```csharp
licenseParameters.Export("keys.txt");
// then, when you need the keys again
using var signingParameters = LicenseSigningParameters.Import("keys.txt");
```

### Creating the License Generator

StandardLicensing License Keys supports a base set of fields for licenses, but also has functionality to support further configuration through generics. This allows you to specify further strongly typed license details in the `KeyData` property.

```Csharp
public class TestLicense 
{
    public int MaxUsers { get; set; }

    public string IssuedTo { get; set; }
}
```

#### Using the Fluent API

StandardLicensing License Keys also supports a fluent API to configure all of its license properties.

```CSharp
using var signingParameters = new LicenseSigningParameters();

var licenseInformation = new TestLicense
{
    MaxUsers = 10000,
    IssuedTo = "Some Random User"
};

var signedLicense = LicenseKeyManager.Create(licenseInformation)
    .WithName("Test License")
    .WithType(LicenseType.Enterprise)
    .WithActivationDate(DateTime.UtcNow.AddDays(1))
    .WithExpirationDate(DateTime.UtcNow.AddDays(30))
    .CreateAndSignLicense(signingParameters);
```

#### Using Standard Assignments

If you do not want to use the fluent API for creation you can call `CreateLicense` on the `ILicenseFactory` interface and manipulate the license with standard assignments, then sign the license later on with the `Sign` method. Example:

```csharp
using var signingParameters = new LicenseSigningParameters();

var licenseInformation = new TestLicense
{
    MaxUsers = 10000,
    IssuedTo = "Some Random User"
};

var license = LicenseKeyManager.Create(licenseInformation)
    .CreateLicense();

license.ExpirationDate = DateTime.UtcNow.AddDays(7);
license.LicenseType = LicenseType.Standard;
var signedLicense = license.Sign(signingParameters)
```

Once you have generated the license then you are free to transport it anywhere. So long as the public key is present the validator should be able to check its contents.

### Validate The License in Your Application

The license data can be stored however you please, however once you start to validate the license you must reconstruct the `SignedLicense` object that the license was originally exported as. This class only consists of two fields, `PublicKey` and `LienseData` so this is not hard to do.

```csharp
var licenseData = GetLicenseData();
var publicKey = GetLicenseKey();

var signedLicense = new SignedLicense(licenseData, publicKey);
```

once you have the `SignedLicense` object, you can use the license validation API to validate your license.

```Csharp

var signedLicense = GetSignedLicense();

if(!signedLicense.SignatureValid())
    throw new Exception("This license has been tampered with!");

var validationResults = LicenseKeyManager.Load<TestLicense>(signedLicense)
    .TypeNot(LicenseType.Trial)
    .ActivatesBefore(DateTime.UtcNow)
    .ExpiresAfter(DateTime.UtcNow, "License is expired")
    .MeetsCondition(license => license.LicenseData.IssuedTo == "Some Random User",
        "This license was issued to Some Random User, and you're not them!")
    .IfExpiresBefore(DateTime.UtcNow.AddDays(7), expirationDate 
        => Console.WriteLine("warning, license expires soon")
    .Validate();

if(validationResults.HasErrors)
    foreach(var error in validationResults.Errors)
        Console.WriteLine(error);
```

StandardLicensing License Keys will not throw any exceptions unless it fails to authenticate the license with its public key.

All errors will be put in the `Errors` property on the `LicenseValidationResults<T>` class and the user will be able to enumerate them manually. This class also exposes the physical license in the `LicenseKey` property, so license values can be read after validation.