### PR TITLE
Fix multi enumeration issue with AssertValidLicense

### DIFF
--- a/src/Standard.Licensing/Validation/ValidationChainBuilder.cs
+++ b/src/Standard.Licensing/Validation/ValidationChainBuilder.cs
@@ -30,14 +30,14 @@ namespace Standard.Licensing.Validation
 {
     internal class ValidationChainBuilder : IStartValidationChain, IValidationChain
     {
-        private readonly Queue<ILicenseValidator> validators;
+        private readonly List<ILicenseValidator> validators;
         private ILicenseValidator currentValidatorChain;
         private readonly License license;
 
         public ValidationChainBuilder(License license)
         {
             this.license = license;
-            validators = new Queue<ILicenseValidator>();
+            validators = new List<ILicenseValidator>();
         }
 
         public ILicenseValidator StartValidatorChain()
@@ -50,7 +50,7 @@ namespace Standard.Licensing.Validation
             if (currentValidatorChain == null)
                 return;
 
-            validators.Enqueue(currentValidatorChain);
+            validators.Add(currentValidatorChain);
             currentValidatorChain = null;
         }
 
@@ -70,9 +70,8 @@ namespace Standard.Licensing.Validation
         {
             CompleteValidatorChain();
 
-            while (validators.Count > 0)
+            foreach (var validator in validators)
             {
-                var validator = validators.Dequeue();
                 if (validator.ValidateWhen != null && !validator.ValidateWhen(license))
                     continue;
 


### PR DESCRIPTION
This fixes issue junian/Standard.Licensing#28
We will now use a List to store validators and will only use them instead of also clearing them.