### PR TITLE
Fix parsing of Expiration. Fix comparison of Expiration. Add unit tests.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot Instructions
+
+## Project Guidelines
+- For this fork, keep .lic expiration storage format unchanged for compatibility, but interpret expiration as a date-only value (timezone-agnostic) during validation.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,114 @@
+# .github/workflows/build.yml
+#
+# Build workflow for Standard.Licensing.
+#
+# - Trigger on pushes, pull requests, and manual dispatch.
+# - Restore, build, test, and pack the NuGet package.
+# - The package project multi-targets .NET 10, 9, 8, 6, .NET Standard 2.0, and .NET Framework 4.6.1/4.8.1.
+# - Upload the generated NuGet packages as a short-lived artifact.
+
+name: Build
+
+on:
+  push:
+    branches: [ '**' ]
+    tags:
+      - 'v*'
+    paths-ignore:
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+      - '**/*.md'
+      - 'LICENSE'
+  pull_request:
+    branches: [ master, main ]
+    paths-ignore:
+      - '**/*.gitignore'
+      - '**/*.gitattributes'
+      - '**/*.md'
+      - 'LICENSE'
+  workflow_dispatch:
+
+env:
+  PROJECT_PATH:        src/Standard.Licensing/Standard.Licensing.csproj
+  TEST_PROJECT_PATH:   src/Standard.Licensing.Tests/Standard.Licensing.Tests.csproj
+  BUILD_CONFIGURATION: Release
+  ARTIFACT_NAME:       package-standard-licensing
+  PUBLISH_FILES_PATH:  ${{ github.workspace }}/artifacts/package
+
+concurrency:
+  group: standard-licensing-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🏗 Build, test, and pack
+    # TODO: Change back when Windows 2025 with VS2026 is available. (4 May 2026)
+    # runs-on: windows-latest
+    runs-on: windows-2025-vs2026
+    permissions:
+      contents: read
+
+    steps:
+      - name: 🧾 Check out repository
+        uses: actions/checkout@v6
+
+      - name: 🛠️ Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+          dotnet-quality: ga
+
+      - name: 📦 Restore NuGet package project
+        run: |
+          dotnet restore "${{ env.PROJECT_PATH }}"
+
+      - name: 📦 Restore test project
+        run: |
+          dotnet restore "${{ env.TEST_PROJECT_PATH }}"
+
+      - name: 🧩 Build NuGet package project
+        run: |
+          dotnet build `
+            "${{ env.PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore
+
+      - name: 🏗 Build test project
+        run: |
+          dotnet build `
+            "${{ env.TEST_PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore
+
+      - name: 💯 Run tests
+        timeout-minutes: 5
+        run: |
+          dotnet test `
+            "${{ env.TEST_PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore `
+            --no-build `
+            --verbosity detailed
+
+      - name: 🧳 Pack NuGet package
+        run: |
+          dotnet pack `
+            "${{ env.PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore `
+            --no-build `
+            --output "${{ env.PUBLISH_FILES_PATH }}"
+
+      - name: 📤 Upload NuGet package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            ${{ env.PUBLISH_FILES_PATH }}/*.nupkg
+            ${{ env.PUBLISH_FILES_PATH }}/*.snupkg
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,103 @@
+# .github/workflows/publish-nuget.yml
+#
+# Manual NuGet publish workflow for Standard.Licensing.12noon.
+#
+# - Triggered only by manual dispatch.
+# - Requires environment approval before publishing.
+# - Restores, builds, and packs the multi-targeted package before publishing to NuGet.org.
+
+name: Publish NuGet Package
+
+on:
+  workflow_dispatch:
+
+env:
+  PROJECT_PATH: src/Standard.Licensing/Standard.Licensing.csproj
+  BUILD_CONFIGURATION: Release
+  PUBLISH_FILES_PATH: ${{ github.workspace }}\artifacts\package
+
+jobs:
+  publish_nuget:
+    name: 🚀 Publish NuGet package
+    # TODO: Change back when Windows 2025 with VS2026 is available. (4 May 2026)
+    # runs-on: windows-latest
+    runs-on: windows-2025-vs2026
+    environment: nuget-prod
+    permissions:
+      contents: read
+
+    steps:
+      - name: 🧾 Check out repository
+        uses: actions/checkout@v6
+
+      - name: 🛠️ Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+          dotnet-quality: ga
+
+      - name: 📦 Restore NuGet package project
+        run: |
+          dotnet restore "${{ env.PROJECT_PATH }}"
+
+      - name: 🧩 Build NuGet package project
+        run: |
+          dotnet build `
+            "${{ env.PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore
+
+      - name: 🧳 Pack NuGet package
+        run: |
+          dotnet pack `
+            "${{ env.PROJECT_PATH }}" `
+            --configuration ${{ env.BUILD_CONFIGURATION }} `
+            --no-restore `
+            --no-build `
+            --include-symbols `
+            --property:SymbolPackageFormat=snupkg `
+            --output "${{ env.PUBLISH_FILES_PATH }}"
+
+      - name: 🔎 List packed artifacts
+        run: |
+          Write-Host "Package output directory: ${{ env.PUBLISH_FILES_PATH }}"
+          if (-not (Test-Path "${{ env.PUBLISH_FILES_PATH }}"))
+          {
+            throw "Package output directory does not exist: ${{ env.PUBLISH_FILES_PATH }}"
+          }
+
+          $allPackages = Get-ChildItem -Path "${{ env.PUBLISH_FILES_PATH }}" -File | Where-Object { $_.Extension -in '.nupkg', '.snupkg' }
+          if ($allPackages.Count -eq 0)
+          {
+            throw "No .nupkg or .snupkg files were found in ${{ env.PUBLISH_FILES_PATH }}"
+          }
+
+          Write-Host "Discovered package files:"
+          $allPackages | ForEach-Object { Write-Host " - $($_.FullName)" }
+
+      - name: 🚀 Publish NuGet package to NuGet.org
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.API_KEY_NUGET }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:NUGET_AUTH_TOKEN))
+          {
+            throw "NUGET_AUTH_TOKEN is missing or empty. Check environment/repository secrets and environment approval."
+          }
+
+          $packages = Get-ChildItem -Path "${{ env.PUBLISH_FILES_PATH }}" -Filter "*.nupkg" -File
+          if ($packages.Count -eq 0)
+          {
+            throw "No .nupkg files found in ${{ env.PUBLISH_FILES_PATH }}"
+          }
+
+          foreach ($package in $packages)
+          {
+            dotnet nuget push "$($package.FullName)" `
+              --source "https://api.nuget.org/v3/index.json" `
+              --api-key "$env:NUGET_AUTH_TOKEN" `
+              --skip-duplicate
+          }

--- a/src/Standard.Licensing.Tests/LicenseSignatureTests.cs
+++ b/src/Standard.Licensing.Tests/LicenseSignatureTests.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+//
 // Copyright © 2012 - 2013 Nauck IT KG     http://www.nauck-it.de
 //
 // Author:
@@ -52,7 +52,12 @@ namespace Standard.Licensing.Tests
         {
             return DateTime.ParseExact(
                 dateTime.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture)
-                , "r", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                , "r", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+        }
+
+        private static DateTime NormalizeToUtcMidnight(DateTime dateTime)
+        {
+            return new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, 0, 0, 0, DateTimeKind.Utc);
         }
 
         [Test]
@@ -80,13 +85,25 @@ namespace Standard.Licensing.Tests
             Assert.That(license.VerifySignature(publicKey), Is.True);
         }
 
-        [Test]
-        public void Can_Generate_And_Validate_Signature_With_Standard_License()
+        public static IEnumerable<TestCaseData> LocalAndUtc
+        {
+            get
+            {
+                yield return new TestCaseData(DateTime.Now.AddMinutes(1));
+                yield return new TestCaseData(DateTime.Now.AddYears(1));
+                yield return new TestCaseData(DateTime.UtcNow.AddMinutes(1));
+                yield return new TestCaseData(DateTime.UtcNow.AddYears(1));
+                yield return new TestCaseData(DateTime.SpecifyKind(DateTime.Now.AddMinutes(1), DateTimeKind.Unspecified));
+                yield return new TestCaseData(DateTime.SpecifyKind(DateTime.Now.AddYears(1), DateTimeKind.Unspecified));
+            }
+        }
+
+        [Test, TestCaseSource(nameof(LocalAndUtc))]
+        public void Can_Generate_And_Validate_Signature_With_Standard_License(DateTime expirationDate)
         {
             var licenseId = Guid.NewGuid();
             var customerName = "Max Mustermann";
             var customerEmail = "max@mustermann.tld";
-            var expirationDate = DateTime.Now.AddYears(1);
             var productFeatures = new Dictionary<string, string>
                                       {
                                           {"Sales Module", "yes"},
@@ -119,7 +136,7 @@ namespace Standard.Licensing.Tests
             Assert.That(license.Customer, Is.Not.Null);
             Assert.That(license.Customer.Name, Is.EqualTo(customerName));
             Assert.That(license.Customer.Email, Is.EqualTo(customerEmail));
-            Assert.That(license.Expiration, Is.EqualTo(ConvertToRfc1123(expirationDate)));
+            Assert.That(license.Expiration, Is.EqualTo(NormalizeToUtcMidnight(expirationDate)));
 
             // verify signature
             Assert.That(license.VerifySignature(publicKey), Is.True);
@@ -174,10 +191,38 @@ namespace Standard.Licensing.Tests
             Assert.That(hackedLicense.Customer, Is.Not.Null);
             Assert.That(hackedLicense.Customer.Name, Is.EqualTo(customerName));
             Assert.That(hackedLicense.Customer.Email, Is.EqualTo(customerEmail));
-            Assert.That(hackedLicense.Expiration, Is.EqualTo(ConvertToRfc1123(expirationDate)));
+            Assert.That(hackedLicense.Expiration, Is.EqualTo(NormalizeToUtcMidnight(expirationDate)));
 
             // verify signature
             Assert.That(hackedLicense.VerifySignature(publicKey), Is.False);
+        }
+
+        public static IEnumerable<TestCaseData> AllDateTimeKinds
+        {
+            get
+            {
+                var date = new DateTime(2030, 6, 15, 14, 30, 0);
+                yield return new TestCaseData(DateTime.SpecifyKind(date, DateTimeKind.Utc)).SetName("Utc");
+                yield return new TestCaseData(DateTime.SpecifyKind(date, DateTimeKind.Local)).SetName("Local");
+                yield return new TestCaseData(DateTime.SpecifyKind(date, DateTimeKind.Unspecified)).SetName("Unspecified");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(AllDateTimeKinds))]
+        public void Expiration_NormalizesToUtcMidnight(DateTime expirationDate)
+        {
+            var expectedUtcMidnight = NormalizeToUtcMidnight(expirationDate);
+
+            var licenseViaBuilder = License.New()
+                .ExpiresAt(expirationDate)
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
+            Assert.That(licenseViaBuilder.Expiration, Is.EqualTo(expectedUtcMidnight));
+            Assert.That(licenseViaBuilder.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
+
+            var licenseViaProperty = License.Load("<License></License>");
+            licenseViaProperty.Expiration = expirationDate;
+            Assert.That(licenseViaProperty.Expiration, Is.EqualTo(expectedUtcMidnight));
+            Assert.That(licenseViaProperty.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
         }
     }
 }

--- a/src/Standard.Licensing.Tests/LicenseValidationTests.cs
+++ b/src/Standard.Licensing.Tests/LicenseValidationTests.cs
@@ -37,26 +37,53 @@ namespace Standard.Licensing.Tests
     [TestFixture]
     public class LicenseValidationTests
     {
+        private License _expiredLicense;
+        private License _notExpiredLicense;
+
+        private static readonly DateTime ExpirationUtc = new DateTime(1899, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime NotExpiredExpirationUtc = new DateTime(2100, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+        [SetUp]
+        public void SetUp()
+        {
+            var passPhrase = Guid.NewGuid().ToString();
+            var keyGenerator = Security.Cryptography.KeyGenerator.Create();
+            var keyPair = keyGenerator.GenerateKeyPair();
+            var privateKey = keyPair.ToEncryptedPrivateKeyString(passPhrase);
+
+            _expiredLicense = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(ExpirationUtc)
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
+
+            _notExpiredLicense = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(NotExpiredExpirationUtc)
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
+        }
+
         [Test]
         public void Can_Validate_Valid_Signature()
         {
-            var publicKey =
-                @"MIIBKjCB4wYHKoZIzj0CATCB1wIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAAAAAAAAAAAAD///////////////8wWwQg/////wAAAAEAAAAAAAAAAAAAAAD///////////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvOPD4n0mBLAxUAxJ02CIbnBJNqZnjhE50mt4GffpAEIQNrF9Hy4SxCR/i85uVjpEDydwN9gS3rM6D0oTlF2JjClgIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABNVLQ1xKY80BFMgGXec++Vw7n8vvNrq32PaHuBiYMm0PEj2JoB7qSSWhfgcjxNVJsxqJ6gDQVWgl0r7LH4dr0KU=";
-            var licenseData = @"<License>
-                                  <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
-                                  <Type>Trial</Type>
-                                  <Expiration>Sun, 31 Dec 1899 23:00:00 GMT</Expiration>
-                                  <Quantity>1</Quantity>
-                                  <Customer>
-                                    <Name>John Doe</Name>
-                                    <Email>john@doe.tld</Email>
-                                  </Customer>
-                                  <LicenseAttributes />
-                                  <ProductFeatures />
-                                  <Signature>MEUCIQCCEDAldOZHHIKvYZRDdzUP4V51y23d6deeK5jIFy27GQIgDz2CndjBh4Vb8tiC3FGQ6fn3GKt8d/P5+luJH0cWv+I=</Signature>
-                                </License>";
+            var passPhrase = Guid.NewGuid().ToString();
+            var keyGenerator = Security.Cryptography.KeyGenerator.Create();
+            var keyPair = keyGenerator.GenerateKeyPair();
+            var privateKey = keyPair.ToEncryptedPrivateKeyString(passPhrase);
+            var publicKey = keyPair.ToPublicKeyString();
 
-            var license = License.Load(licenseData);
+			   License license = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(new DateTime(1899, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
 
             var validationResults = license
                 .Validate()
@@ -70,25 +97,23 @@ namespace Standard.Licensing.Tests
         [Test]
         public void Can_Validate_Invalid_Signature()
         {
-            var publicKey =
-                @"MIIBKjCB4wYHKoZIzj0CATCB1wIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAAAAAAAAAAAAD///////////////8wWwQg/////wAAAAEAAAAAAAAAAAAAAAD///////////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvOPD4n0mBLAxUAxJ02CIbnBJNqZnjhE50mt4GffpAEIQNrF9Hy4SxCR/i85uVjpEDydwN9gS3rM6D0oTlF2JjClgIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABNVLQ1xKY80BFMgGXec++Vw7n8vvNrq32PaHuBiYMm0PEj2JoB7qSSWhfgcjxNVJsxqJ6gDQVWgl0r7LH4dr0KU=";
-            var licenseData = @"<License>
-                                  <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
-                                  <Type>Trial</Type>
-                                  <Expiration>Sun, 31 Dec 1899 23:00:00 GMT</Expiration>
-                                  <Quantity>999</Quantity>
-                                  <Customer>
-                                    <Name>John Doe</Name>
-                                    <Email>john@doe.tld</Email>
-                                  </Customer>
-                                  <LicenseAttributes />
-                                  <ProductFeatures />
-                                  <Signature>MEUCIQCCEDAldOZHHIKvYZRDdzUP4V51y23d6deeK5jIFy27GQIgDz2CndjBh4Vb8tiC3FGQ6fn3GKt8d/P5+luJH0cWv+I=</Signature>
-                                </License>";
+            var passPhrase = Guid.NewGuid().ToString();
+            var keyGenerator = Security.Cryptography.KeyGenerator.Create();
+            var keyPair = keyGenerator.GenerateKeyPair();
+            var privateKey = keyPair.ToEncryptedPrivateKeyString(passPhrase);
+            var publicKey = keyPair.ToPublicKeyString();
 
-            var license = License.Load(licenseData);
+			   License license = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(new DateTime(1899, 12, 31, 0, 0, 0, DateTimeKind.Utc))
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
 
-            var validationResults = license
+			   License tamperedLicense = License.Load(license.ToString().Replace("<Quantity>1</Quantity>", "<Quantity>999</Quantity>"));
+
+            var validationResults = tamperedLicense
                 .Validate()
                 .Signature(publicKey)
                 .AssertValidLicense().ToList();
@@ -101,24 +126,9 @@ namespace Standard.Licensing.Tests
         [Test]
         public void Can_Validate_Expired_ExpirationDate()
         {
-            var publicKey = "";
-            var licenseData = @"<License>
-                                  <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
-                                  <Type>Trial</Type>
-                                  <Expiration>Sun, 31 Dec 1899 23:00:00 GMT</Expiration>
-                                  <Quantity>1</Quantity>
-                                  <Customer>
-                                    <Name>John Doe</Name>
-                                    <Email>john@doe.tld</Email>
-                                  </Customer>
-                                  <LicenseAttributes />
-                                  <ProductFeatures />
-                                  <Signature>MEUCIQCCEDAldOZHHIKvYZRDdzUP4V51y23d6deeK5jIFy27GQIgDz2CndjBh4Vb8tiC3FGQ6fn3GKt8d/P5+luJH0cWv+I=</Signature>
-                                </License>";
+            Assert.That(_expiredLicense.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
 
-            var license = License.Load(licenseData);
-
-            var validationResults = license
+            var validationResults = _expiredLicense
                 .Validate()
                 .ExpirationDate()
                 .AssertValidLicense().ToList();
@@ -126,65 +136,128 @@ namespace Standard.Licensing.Tests
             Assert.That(validationResults, Is.Not.Null);
             Assert.That(validationResults.Count(), Is.EqualTo(1));
             Assert.That(validationResults.FirstOrDefault(), Is.TypeOf<LicenseExpiredValidationFailure>());
-
         }
 
         [Test]
-        public void Can_Validate_Expired_ExpirationDate_CustomDateTime()
+        public void Can_Validate_NotExpired_ExpirationDate()
         {
-            var publicKey = "";
-            var licenseData = @"<License>
-                                  <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
-                                  <Type>Trial</Type>
-                                  <Expiration>Sun, 31 Dec 1899 23:00:00 GMT</Expiration>
-                                  <Quantity>1</Quantity>
-                                  <Customer>
-                                    <Name>John Doe</Name>
-                                    <Email>john@doe.tld</Email>
-                                  </Customer>
-                                  <LicenseAttributes />
-                                  <ProductFeatures />
-                                  <Signature>MEUCIQCCEDAldOZHHIKvYZRDdzUP4V51y23d6deeK5jIFy27GQIgDz2CndjBh4Vb8tiC3FGQ6fn3GKt8d/P5+luJH0cWv+I=</Signature>
-                                </License>";
+            Assert.That(_notExpiredLicense.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
 
-            var license = License.Load(licenseData);
-
-            var validationResults = license
+            var validationResults = _notExpiredLicense
                 .Validate()
-                .ExpirationDate(systemDateTime: new DateTime(1900, 1, 2, 0, 0, 0, DateTimeKind.Utc))
+                .ExpirationDate()
+                .AssertValidLicense().ToList();
+
+            Assert.That(validationResults, Is.Not.Null);
+            Assert.That(validationResults.Count(), Is.EqualTo(0));
+        }
+
+        public static IEnumerable<TestCaseData> LocalAndUtcExpired
+        {
+            get
+            {
+                var expirationLocalDate = new DateTime(ExpirationUtc.Year, ExpirationUtc.Month, ExpirationUtc.Day, 0, 0, 0, DateTimeKind.Local);
+                var expirationLocalDateAtOneMinutePastMidnight = expirationLocalDate.AddMinutes(1);
+                var expirationLocalDateAtThirtyMinutesPastMidnight = expirationLocalDate.AddMinutes(30);
+                var expirationLocalDateAtNoon = expirationLocalDate.AddHours(12);
+                var expirationLocalDateTomorrow = expirationLocalDate.AddDays(1);
+
+                yield return new TestCaseData(expirationLocalDate);
+                yield return new TestCaseData(expirationLocalDateAtOneMinutePastMidnight);
+                yield return new TestCaseData(expirationLocalDateAtThirtyMinutesPastMidnight);
+                yield return new TestCaseData(expirationLocalDateAtNoon);
+                yield return new TestCaseData(expirationLocalDateTomorrow);
+
+                yield return new TestCaseData(expirationLocalDate.ToUniversalTime());
+                yield return new TestCaseData(expirationLocalDateAtOneMinutePastMidnight.ToUniversalTime());
+                yield return new TestCaseData(expirationLocalDateAtThirtyMinutesPastMidnight.ToUniversalTime());
+                yield return new TestCaseData(expirationLocalDateAtNoon.ToUniversalTime());
+                yield return new TestCaseData(expirationLocalDateTomorrow.ToUniversalTime());
+            }
+        }
+
+        [Test, TestCaseSource(nameof(LocalAndUtcExpired))]
+        public void Can_Validate_Expired_ExpirationDate_CustomDateTime(DateTime currentDate)
+        {
+            Assert.That(_expiredLicense.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
+
+            var validationResults = _expiredLicense
+                .Validate()
+                .ExpirationDate(systemDateTime: currentDate)
                 .AssertValidLicense().ToList();
 
             Assert.That(validationResults, Is.Not.Null);
             Assert.That(validationResults.Count(), Is.EqualTo(1));
             Assert.That(validationResults.FirstOrDefault(), Is.TypeOf<LicenseExpiredValidationFailure>());
+        }
 
+        public static IEnumerable<TestCaseData> LocalAndUtcNotExpired
+        {
+            get
+            {
+                var dayBeforeExpirationLocalDate = new DateTime(ExpirationUtc.Year, ExpirationUtc.Month, ExpirationUtc.Day, 0, 0, 0, DateTimeKind.Local).AddDays(-1);
+                var dayBeforeExpirationLocalDateAtOneMinutePastMidnight = dayBeforeExpirationLocalDate.AddMinutes(1);
+                var dayBeforeExpirationLocalDateAtThirtyMinutesPastMidnight = dayBeforeExpirationLocalDate.AddMinutes(30);
+                var dayBeforeExpirationLocalDateAtNoon = dayBeforeExpirationLocalDate.AddHours(12);
+                var dayBeforeExpirationLocalDateAtThirtyMinutesBeforeMidnight = dayBeforeExpirationLocalDate.AddHours(23).AddMinutes(30);
+                var dayBeforeExpirationLocalDateAtOneMinuteBeforeMidnight = dayBeforeExpirationLocalDate.AddHours(23).AddMinutes(59);
+
+                yield return new TestCaseData(dayBeforeExpirationLocalDate);
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtOneMinutePastMidnight);
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtThirtyMinutesPastMidnight);
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtNoon);
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtThirtyMinutesBeforeMidnight);
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtOneMinuteBeforeMidnight);
+
+                yield return new TestCaseData(dayBeforeExpirationLocalDate.ToUniversalTime());
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtOneMinutePastMidnight.ToUniversalTime());
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtThirtyMinutesPastMidnight.ToUniversalTime());
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtNoon.ToUniversalTime());
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtThirtyMinutesBeforeMidnight.ToUniversalTime());
+                yield return new TestCaseData(dayBeforeExpirationLocalDateAtOneMinuteBeforeMidnight.ToUniversalTime());
+            }
+        }
+
+        [Test, TestCaseSource(nameof(LocalAndUtcNotExpired))]
+        public void Can_Validate_NotExpired_ExpirationDate_CustomDateTime(DateTime currentDate)
+        {
+            Assert.That(_expiredLicense.Expiration.Kind, Is.EqualTo(DateTimeKind.Utc));
+
+            var validationResults = _expiredLicense
+                .Validate()
+                .ExpirationDate(systemDateTime: currentDate)
+                .AssertValidLicense().ToList();
+
+            Assert.That(validationResults, Is.Not.Null);
+            Assert.That(validationResults.Count(), Is.EqualTo(0));
         }
 
         [Test]
         public void Can_Validate_CustomAssertion()
         {
-            var publicKey = @"MIIBKjCB4wYHKoZIzj0CATCB1wIBATAsBgcqhkjOPQEBAiEA/////wAAAAEAAAAAAAAAAAAAAAD///////////////8wWwQg/////wAAAAEAAAAAAAAAAAAAAAD///////////////wEIFrGNdiqOpPns+u9VXaYhrxlHQawzFOw9jvOPD4n0mBLAxUAxJ02CIbnBJNqZnjhE50mt4GffpAEIQNrF9Hy4SxCR/i85uVjpEDydwN9gS3rM6D0oTlF2JjClgIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABNVLQ1xKY80BFMgGXec++Vw7n8vvNrq32PaHuBiYMm0PEj2JoB7qSSWhfgcjxNVJsxqJ6gDQVWgl0r7LH4dr0KU=";
-            var licenseData = @"<License>
-                              <Id>77d4c193-6088-4c64-9663-ed7398ae8c1a</Id>
-                              <Type>Trial</Type>
-                              <Expiration>Thu, 31 Dec 2009 23:00:00 GMT</Expiration>
-                              <Quantity>1</Quantity>
-                              <Customer>
-                                <Name>John Doe</Name>
-                                <Email>john@doe.tld</Email>
-                              </Customer>
-                              <LicenseAttributes>
-                                <Attribute name=""Assembly Signature"">123456789</Attribute>
-                              </LicenseAttributes>
-                              <ProductFeatures>
-                                <Feature name=""Sales Module"">yes</Feature>
-                                <Feature name=""Workflow Module"">yes</Feature>
-                                <Feature name=""Maximum Transactions"">10000</Feature>
-                              </ProductFeatures>
-                              <Signature>MEUCIQCa6A7Cts5ex4rGHAPxiXpy+2ocZzTDSP7SsddopKUx5QIgHnqv0DjoOpc+K9wALqajxxvmLCRJAywCX5vDAjmWqr8=</Signature>
-                            </License>";
+            var passPhrase = Guid.NewGuid().ToString();
+            var keyGenerator = Security.Cryptography.KeyGenerator.Create();
+            var keyPair = keyGenerator.GenerateKeyPair();
+            var privateKey = keyPair.ToEncryptedPrivateKeyString(passPhrase);
+            var publicKey = keyPair.ToPublicKeyString();
 
-            var license = License.Load(licenseData);
+            var license = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(new DateTime(2009, 12, 31, 23, 0, 0, DateTimeKind.Utc))
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .WithAdditionalAttributes(new Dictionary<string, string>
+                    {
+                        {"Assembly Signature", "123456789"},
+                    })
+                .WithProductFeatures(new Dictionary<string, string>
+                    {
+                        {"Sales Module", "yes"},
+                        {"Workflow Module", "yes"},
+                        {"Maximum Transactions", "10000"},
+                    })
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
 
             var validationResults = license
                 .Validate()
@@ -248,6 +321,44 @@ namespace Standard.Licensing.Tests
             Assert.That(count, Is.EqualTo(1));
             Assert.That(validationFailures.ToArray().Length, Is.EqualTo(1));
             Assert.That(validationFailures.ToArray().Length, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ExpirationDate_IsInvalidStartingAtLocalMidnight_OnStoredExpirationDate()
+        {
+            var passPhrase = Guid.NewGuid().ToString();
+            var keyGenerator = Security.Cryptography.KeyGenerator.Create();
+            var keyPair = keyGenerator.GenerateKeyPair();
+            var privateKey = keyPair.ToEncryptedPrivateKeyString(passPhrase);
+
+            var expirationUtc = new DateTime(2030, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            var license = License.New()
+                .WithUniqueIdentifier(new Guid("77d4c193-6088-4c64-9663-ed7398ae8c1a"))
+                .As(LicenseType.Trial)
+                .ExpiresAt(expirationUtc)
+                .WithMaximumUtilization(1)
+                .LicensedTo("John Doe", "john@doe.tld")
+                .CreateAndSignWithPrivateKey(privateKey, passPhrase);
+
+            var oneMinuteBeforeLocalMidnight = new DateTime(2030, 5, 31, 23, 59, 0, DateTimeKind.Local);
+            var atLocalMidnight = new DateTime(2030, 6, 1, 0, 0, 0, DateTimeKind.Local);
+
+            var validationBeforeMidnight = license
+                .Validate()
+                .ExpirationDate(systemDateTime: oneMinuteBeforeLocalMidnight)
+                .AssertValidLicense().ToList();
+
+            var validationAtMidnight = license
+                .Validate()
+                .ExpirationDate(systemDateTime: atLocalMidnight)
+                .AssertValidLicense().ToList();
+
+            Assert.That(validationBeforeMidnight, Is.Not.Null);
+            Assert.That(validationBeforeMidnight.Count(), Is.EqualTo(0));
+
+            Assert.That(validationAtMidnight, Is.Not.Null);
+            Assert.That(validationAtMidnight.Count(), Is.EqualTo(1));
+            Assert.That(validationAtMidnight.FirstOrDefault(), Is.TypeOf<LicenseExpiredValidationFailure>());
         }
     }
 }

--- a/src/Standard.Licensing.Tests/Standard.Licensing.Tests.csproj
+++ b/src/Standard.Licensing.Tests/Standard.Licensing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;net48;net481</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/Standard.Licensing.slnx
+++ b/src/Standard.Licensing.slnx
@@ -1,4 +1,8 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="../.github/workflows/build.yml" />
+    <File Path="../.github/workflows/publish-nuget.yml" />
+  </Folder>
   <Project Path="Standard.Licensing.Tests/Standard.Licensing.Tests.csproj" />
   <Project Path="Standard.Licensing/Standard.Licensing.csproj" />
 </Solution>

--- a/src/Standard.Licensing/License.cs
+++ b/src/Standard.Licensing/License.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+﻿//
 // Copyright © 2012 - 2013 Nauck IT KG     http://www.nauck-it.de
 //
 // Author:
@@ -165,10 +165,17 @@ namespace Standard.Licensing
         }
 
         /// <summary>
-        /// Gets or sets the expiration date of this <see cref="License"/>.
+        /// Gets or sets the expiration date in UTC of this <see cref="License"/>.
         /// Use this property to set the expiration date for a trial license
         /// or the expiration of support & subscription updates for a standard license.
         /// </summary>
+        /// <remarks>
+        /// When setting this value, only the year/month/day components are used.
+        /// Time-of-day and <see cref="DateTimeKind"/> are ignored.
+        /// The stored value is normalized to UTC midnight for that date.
+        /// </remarks>
+        /// <param name="value">The expiration date of the <see cref="License"/>. Only its date component is used.</param>
+        /// <returns>The expiration date of the <see cref="License"/> as UTC midnight.</returns>
         public DateTime Expiration
         {
             get
@@ -176,10 +183,17 @@ namespace Standard.Licensing
                 return
                     DateTime.ParseExact(
                         GetTag("Expiration") ??
-                        DateTime.MaxValue.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture)
-                        , "r", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                        DateTime.MaxValue.ToString("r", CultureInfo.InvariantCulture)
+                        , "r", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
             }
-            set { if (!IsSigned) SetTag("Expiration", value.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture)); }
+            set
+            {
+                if (!IsSigned)
+                {
+					     DateTime normalizedUtcDate = new DateTime(value.Year, value.Month, value.Day, 0, 0, 0, DateTimeKind.Utc);
+                    SetTag("Expiration", normalizedUtcDate.ToString("r", CultureInfo.InvariantCulture));
+                }
+            }
         }
 
         /// <summary>

--- a/src/Standard.Licensing/LicenseBuilder.cs
+++ b/src/Standard.Licensing/LicenseBuilder.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+//
 // Copyright © 2012 - 2013 Nauck IT KG     http://www.nauck-it.de
 //
 // Author:
@@ -69,11 +69,16 @@ namespace Standard.Licensing
         /// <summary>
         /// Sets the expiration date of the <see cref="License"/>.
         /// </summary>
-        /// <param name="date">The expiration date of the <see cref="License"/>.</param>
+        /// <remarks>
+        /// Only the year/month/day components are used.
+        /// Time-of-day and <see cref="DateTimeKind"/> are ignored.
+        /// The value is normalized to UTC midnight for that date.
+        /// </remarks>
+        /// <param name="date">The expiration date of the <see cref="License"/>. Only its date component is used.</param>
         /// <returns>The <see cref="ILicenseBuilder"/>.</returns>
         public ILicenseBuilder ExpiresAt(DateTime date)
         {
-            license.Expiration = date.ToUniversalTime();
+            license.Expiration = new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, DateTimeKind.Utc);
             return this;
         }
 

--- a/src/Standard.Licensing/Standard.Licensing.csproj
+++ b/src/Standard.Licensing/Standard.Licensing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;netstandard2.0;net461;net481</TargetFrameworks>
     <RootNamespace>Standard.Licensing</RootNamespace>
     <AssemblyName>Standard.Licensing</AssemblyName>
     <Authors>Junian Triajianto</Authors>

--- a/src/Standard.Licensing/Standard.Licensing.csproj
+++ b/src/Standard.Licensing/Standard.Licensing.csproj
@@ -4,33 +4,37 @@
     <TargetFrameworks>net10.0;net9.0;net8.0;net6.0;netstandard2.0;net461;net481</TargetFrameworks>
     <RootNamespace>Standard.Licensing</RootNamespace>
     <AssemblyName>Standard.Licensing</AssemblyName>
-    <Authors>Junian Triajianto</Authors>
+    <Authors>Junian Triajianto; Stefan K.S. Tucker</Authors>
     <NeutralLanguage>en</NeutralLanguage>
-    <Owners>junian</Owners>
+    <Owners>junian; 12noon LLC</Owners>
     <PackageProjectUrl>https://www.junian.dev/Standard.Licensing/</PackageProjectUrl>
     <PackageReleaseNotes>
-        v1.2.2
-        
-        - Add .NET 10.0 Support
-        
-        v1.2.1
-        
-        - Add .NET 9.0 Support
+		 v1.3.0
 
-        v1.2.0
+		 - Update ExpirationDate to use only the date part, ignoring the time component, to prevent unexpected expiration issues due to time zone differences or time component discrepancies.
 
-        - Update to the latest BouncyCastle
+		 v1.2.2
 
-        v1.1.9
+		 - Add .NET 10.0 Support
 
-        - Add custom DateTime to check Expiration date</PackageReleaseNotes>
+		 v1.2.1
+
+		 - Add .NET 9.0 Support
+
+		 v1.2.0
+
+		 - Update to the latest BouncyCastle
+
+		 v1.1.9
+
+		 - Add custom DateTime to check Expiration date</PackageReleaseNotes>
     <Summary>Easy-to-use licensing library for .NET and .NET Framework products.</Summary>
     <PackageTags>portable,licensing,key</PackageTags>
-    <Title>Standard.Licensing</Title>
+    <Title>Standard.Licensing.12noon</Title>
     <Description>Easy-to-use licensing library for .NET and .NET Framework products.</Description>
-    <PackageId>Standard.Licensing</PackageId>
+    <PackageId>Standard.Licensing.12noon</PackageId>
     <Copyright>Copyright (c) 2018 - 2026</Copyright>
-    <RepositoryUrl>https://github.com/junian/Standard.Licensing</RepositoryUrl>
+    <RepositoryUrl>https://github.com/12noonLLC/Standard.Licensing</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Standard.Licensing.snk</AssemblyOriginatorKeyFile>
@@ -42,10 +46,12 @@
     <CLSCompliant>True</CLSCompliant>
 	
     <!-- Versions -->
-    <AssemblyVersion>1.2.2.0</AssemblyVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
     <ReleaseVersion>$(AssemblyVersion)</ReleaseVersion>
     <Version>$(AssemblyVersion)</Version>
     <FileVersion>$(AssemblyVersion)</FileVersion>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/src/Standard.Licensing/Validation/LicenseValidationExtensions.cs
+++ b/src/Standard.Licensing/Validation/LicenseValidationExtensions.cs
@@ -59,14 +59,22 @@ namespace Standard.Licensing.Validation
         /// <summary>
         /// Validates if the license has been expired.
         /// </summary>
+        /// <remarks>
+        /// This comparison uses calendar dates only.
+        /// The stored expiration value and system date are compared as <see cref="DateOnly"/> values.
+        /// </remarks>
         /// <param name="validationChain">The current <see cref="IStartValidationChain"/>.</param>
-        /// <param name="systemDateTime">The System DateTime to compare to, default is DateTime.Now. Can be changed to NTP / other internet API times.</param>
+        /// <param name="systemDateTime">The system DateTime to compare to in local time or UTC, default is DateTime.Now. Can be changed to NTP / other internet API times.</param>
         /// <returns>An instance of <see cref="IStartValidationChain"/>.</returns>
         public static IValidationChain ExpirationDate(this IStartValidationChain validationChain, DateTime systemDateTime)
         {
             var validationChainBuilder = (validationChain as ValidationChainBuilder);
             var validator = validationChainBuilder.StartValidatorChain();
-            validator.Validate = license => license.Expiration > systemDateTime;
+#if NET6_0_OR_GREATER
+            validator.Validate = license => DateOnly.FromDateTime(license.Expiration) > DateOnly.FromDateTime(systemDateTime.ToLocalTime());
+#else
+            validator.Validate = license => license.Expiration.Date > systemDateTime.ToLocalTime().Date;
+#endif
 
             validator.FailureResult = new LicenseExpiredValidationFailure()
             {


### PR DESCRIPTION
This PR fixes #17.

* The `Expiration` property was returning an **Unspecified** `DateTime` type. Added the **AdjustToUniversal** style to `Parse`.
* Convert `DateTime` passed to `ExpirationDate` to UTC before comparing with `Expiration` property (which is UTC).
* Added a validation to `Expiration.set` to ensure the incoming type is not **Unspecified**.
* Added a validation to `ExpiresAt` to ensure the incoming type is not **Unspecified**.
* Added more unit tests around `ExpiresAt` and `Expiration`.
* All unit tests pass.

This is my first pull request ever. 🙂 I tried to add relevant tests and to maintain the project's coding style (indents, spaces not tabs, etc.). If I introduced an error or missed something, please let me know, and I will be happy to correct it.